### PR TITLE
使用最后支持Ubuntu 18.04的Pwndbg版本

### DIFF
--- a/pwn_init_py3.sh
+++ b/pwn_init_py3.sh
@@ -29,7 +29,7 @@ sudo apt-get -y install libc6-i386
 sudo apt-get -y install git gdb
 # install pwndbg
 git clone https://github.com/pwndbg/pwndbg
-cd pwndbg
+cd pwndbg && git checkout 71c4e1d6f382f997d7526fa15bb77191577ca367
 ./setup.sh
 # install peda
 git clone https://github.com/longld/peda.git ~/peda


### PR DESCRIPTION
Hi giantbranch!
I find that Pwndbg has drop the support for python 3.6 and 3.7 since Mar. 2023, which means its newest version has not support Ubuntu 18.04. So I change the pwndbg to the latest of Ubuntu 18.04-support version.

References:
- https://github.com/pwndbg/pwndbg/issues/1744#issue-1724823301
- https://github.com/pwndbg/pwndbg/pull/1840